### PR TITLE
feat: basic expedia api integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+API_TOKEN=secret-token
+EXPEDIA_API_KEY=demo-key

--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
-# expedia_example
+# Expedia Laravel API Example
+
+This project provides a minimal Laravel-style API for integrating with the Expedia Rapid Lodging API.
+
+## Endpoints
+
+- `GET /api/expedia/hotels?cityId=1506246` – Fetches hotel data from Expedia.
+
+Requests must include the header `X-API-TOKEN` with the value defined in `.env` as `API_TOKEN`.
+
+## Tests
+
+Tests use `Laravel HTTP::fake()` to mock Expedia responses. Run tests with:
+
+```bash
+composer install
+./vendor/bin/phpunit
+```
+
+Because this repository does not include vendor libraries, run `composer install` before executing tests.

--- a/app/Http/Controllers/ExpediaController.php
+++ b/app/Http/Controllers/ExpediaController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class ExpediaController extends Controller
+{
+    /**
+     * Retrieve hotels from Expedia Rapid API.
+     */
+    public function searchHotels(Request $request)
+    {
+        $response = Http::withHeaders([
+            'Accept' => 'application/json',
+            'Authorization' => 'Bearer ' . config('services.expedia.key'),
+        ])->get('https://test.expediapartnercentral.com/rapid/hotels', [
+            'cityId' => $request->query('cityId', '1506246'),
+            'room1' => '2',
+        ]);
+
+        return response()->json($response->json(), $response->status());
+    }
+}

--- a/app/Http/Middleware/ApiTokenMiddleware.php
+++ b/app/Http/Middleware/ApiTokenMiddleware.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+
+class ApiTokenMiddleware
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $token = $request->header('X-API-TOKEN');
+        if ($token !== config('app.api_token')) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+        return $next($request);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,22 @@
+{
+    "name": "expedia/example",
+    "description": "Laravel API to integrate Expedia content",
+    "type": "project",
+    "require": {
+        "php": "^8.1",
+        "laravel/framework": "^11.0",
+        "guzzlehttp/guzzle": "^7.0",
+        "firebase/php-jwt": "^6.0"
+    },
+    "require-dev": {
+        "phpunit/phpunit": "^11.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "App\\": "app/"
+        }
+    },
+    "scripts": {
+        "test": "phpunit"
+    }
+}

--- a/config/app.php
+++ b/config/app.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'api_token' => env('API_TOKEN', 'secret-token'),
+];

--- a/config/services.php
+++ b/config/services.php
@@ -1,0 +1,7 @@
+<?php
+
+return [
+    'expedia' => [
+        'key' => env('EXPEDIA_API_KEY', 'demo-key'),
+    ],
+];

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="vendor/autoload.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="false">
+    <testsuites>
+        <testsuite name="Feature">
+            <directory suffix="Test.php">tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+</phpunit>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,9 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\ExpediaController;
+use App\Http\Middleware\ApiTokenMiddleware;
+
+Route::middleware([ApiTokenMiddleware::class])->group(function () {
+    Route::get('/expedia/hotels', [ExpediaController::class, 'searchHotels']);
+});

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\ExpediaController;
+use App\Http\Middleware\ApiTokenMiddleware;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\TestCase;
+
+class AuthenticationTest extends TestCase
+{
+    public function test_request_without_token_is_unauthorized()
+    {
+        $middleware = new ApiTokenMiddleware();
+        $controller = new ExpediaController();
+        $request = Request::create('/api/expedia/hotels', 'GET');
+
+        $response = $middleware->handle($request, fn($req) => $controller->searchHotels($req));
+
+        $this->assertEquals(401, $response->status());
+    }
+}

--- a/tests/Feature/ExpediaControllerTest.php
+++ b/tests/Feature/ExpediaControllerTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Http\Controllers\ExpediaController;
+use App\Http\Middleware\ApiTokenMiddleware;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\TestCase;
+
+class ExpediaControllerTest extends TestCase
+{
+    public function test_search_hotels_returns_response()
+    {
+        Http::fake([
+            'https://test.expediapartnercentral.com/rapid/hotels*' => Http::response([
+                'hotels' => [
+                    ['id' => '1', 'name' => 'Demo Hotel']
+                ]
+            ], 200)
+        ]);
+
+        $request = Request::create('/api/expedia/hotels', 'GET', ['cityId' => '1506246']);
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->searchHotels($req));
+
+        $this->assertEquals(200, $response->status());
+        $this->assertNotEmpty($response->getData(true)['hotels']);
+    }
+}


### PR DESCRIPTION
## Summary
- add Expedia controller and middleware protecting routes with internal token
- stub API route and configuration for Expedia Rapid Lodging integration
- include feature tests using HTTP fakes and auth checks

## Testing
- `./vendor/bin/phpunit` *(fails: No such file or directory)*
- `composer install` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68938f2d95cc8330bd9860b559bc0b24