### PR TITLE
Add Expedia region endpoint

### DIFF
--- a/app/Http/Controllers/ExpediaController.php
+++ b/app/Http/Controllers/ExpediaController.php
@@ -22,4 +22,19 @@ class ExpediaController extends Controller
 
         return response()->json($response->json(), $response->status());
     }
+
+    /**
+     * Retrieve region information from Expedia Rapid API.
+     */
+    public function getRegion(Request $request, string $region_id)
+    {
+        $params = $request->only(['language', 'include']);
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/json',
+            'Authorization' => 'Bearer ' . config('services.expedia.key'),
+        ])->get("https://test.expediapartnercentral.com/rapid/regions/{$region_id}", $params);
+
+        return response()->json($response->json(), $response->status());
+    }
 }

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,4 +6,5 @@ use App\Http\Middleware\ApiTokenMiddleware;
 
 Route::middleware([ApiTokenMiddleware::class])->group(function () {
     Route::get('/expedia/hotels', [ExpediaController::class, 'searchHotels']);
+    Route::get('/expedia/region/{region_id}', [ExpediaController::class, 'getRegion']);
 });

--- a/tests/Feature/ExpediaControllerTest.php
+++ b/tests/Feature/ExpediaControllerTest.php
@@ -30,4 +30,24 @@ class ExpediaControllerTest extends TestCase
         $this->assertEquals(200, $response->status());
         $this->assertNotEmpty($response->getData(true)['hotels']);
     }
+
+    public function test_get_region_returns_response()
+    {
+        Http::fake([
+            'https://test.expediapartnercentral.com/rapid/regions/*' => Http::response([
+                'id' => '1',
+                'name' => 'Demo Region'
+            ], 200)
+        ]);
+
+        $request = Request::create('/api/expedia/region/1', 'GET', ['language' => 'en-US', 'include' => 'details']);
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->getRegion($req, '1'));
+
+        $this->assertEquals(200, $response->status());
+        $this->assertEquals('Demo Region', $response->getData(true)['name']);
+    }
 }


### PR DESCRIPTION
## Summary
- add new Expedia region retrieval endpoint with optional language and include parameters
- expose `/expedia/region/{region_id}` route
- test region endpoint behavior

## Testing
- `composer test` *(fails: phpunit not found)*
- `composer install` *(fails: curl error 56, CONNECT tunnel failed 403)*

------
https://chatgpt.com/codex/tasks/task_e_689398c5a1048330a9145dac3d438148