### PR TITLE
Validate Expedia query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,18 @@ This project provides a minimal Laravel-style API for integrating with the Exped
 
 ## Endpoints
 
-- `GET /api/expedia/hotels?cityId=1506246` – Fetches hotel data from Expedia.
+- `GET /api/expedia/hotels?cityId=1506246&checkin=2024-09-01&checkout=2024-09-05&room1=2` – Fetches hotel data from Expedia.
 
 Requests must include the header `X-API-TOKEN` with the value defined in `.env` as `API_TOKEN`.
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `cityId`  | int  | Expedia city identifier. |
+| `checkin` | date (`YYYY-MM-DD`) | Check-in date. |
+| `checkout` | date (`YYYY-MM-DD`) | Check-out date, must be after `checkin`. |
+| `room1` | string | Room occupancy description, e.g. `2` for two adults. |
 
 ## Tests
 

--- a/app/Http/Controllers/ExpediaController.php
+++ b/app/Http/Controllers/ExpediaController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
 
 class ExpediaController extends Controller
 {
@@ -12,13 +13,23 @@ class ExpediaController extends Controller
      */
     public function searchHotels(Request $request)
     {
+        $validator = Validator::make($request->all(), [
+            'cityId' => 'required|integer',
+            'checkin' => 'required|date_format:Y-m-d',
+            'checkout' => 'required|date_format:Y-m-d|after:checkin',
+            'room1' => 'required|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $params = $validator->validated();
+
         $response = Http::withHeaders([
             'Accept' => 'application/json',
             'Authorization' => 'Bearer ' . config('services.expedia.key'),
-        ])->get('https://test.expediapartnercentral.com/rapid/hotels', [
-            'cityId' => $request->query('cityId', '1506246'),
-            'room1' => '2',
-        ]);
+        ])->get('https://test.expediapartnercentral.com/rapid/hotels', $params);
 
         return response()->json($response->json(), $response->status());
     }

--- a/tests/Feature/ExpediaControllerTest.php
+++ b/tests/Feature/ExpediaControllerTest.php
@@ -12,15 +12,20 @@ class ExpediaControllerTest extends TestCase
 {
     public function test_search_hotels_returns_response()
     {
-        Http::fake([
-            'https://test.expediapartnercentral.com/rapid/hotels*' => Http::response([
+        Http::fake(function ($request) {
+            return Http::response([
                 'hotels' => [
                     ['id' => '1', 'name' => 'Demo Hotel']
                 ]
-            ], 200)
-        ]);
+            ], 200);
+        });
 
-        $request = Request::create('/api/expedia/hotels', 'GET', ['cityId' => '1506246']);
+        $request = Request::create('/api/expedia/hotels', 'GET', [
+            'cityId' => '1506246',
+            'checkin' => '2024-09-01',
+            'checkout' => '2024-09-05',
+            'room1' => '2',
+        ]);
         $request->headers->set('X-API-TOKEN', 'secret-token');
 
         $controller = new ExpediaController();
@@ -29,5 +34,27 @@ class ExpediaControllerTest extends TestCase
 
         $this->assertEquals(200, $response->status());
         $this->assertNotEmpty($response->getData(true)['hotels']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://test.expediapartnercentral.com/rapid/hotels'
+                && $request['cityId'] === '1506246'
+                && $request['checkin'] === '2024-09-01'
+                && $request['checkout'] === '2024-09-05'
+                && $request['room1'] === '2';
+        });
+    }
+
+    public function test_search_hotels_requires_parameters()
+    {
+        Http::fake();
+
+        $request = Request::create('/api/expedia/hotels', 'GET');
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->searchHotels($req));
+
+        $this->assertEquals(422, $response->status());
     }
 }


### PR DESCRIPTION
## Summary
- validate cityId, checkin, checkout, and room1 inputs before querying Expedia
- pass only validated parameters to Expedia API calls
- document supported query parameters in README

## Testing
- `composer install --no-interaction --no-progress` *(failed: CONNECT tunnel failed, response 403)*
- `composer test` *(failed: phpunit: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689398d245c883308da70400cf62361f