### PR TITLE
Add ExpediaController tests for success and error scenarios

### DIFF
--- a/tests/Feature/ExpediaControllerTest.php
+++ b/tests/Feature/ExpediaControllerTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
 
 class ExpediaControllerTest extends TestCase
 {
-    public function test_search_hotels_returns_response()
+    public function test_search_hotels_success()
     {
         Http::fake([
             'https://test.expediapartnercentral.com/rapid/hotels*' => Http::response([
@@ -27,7 +27,34 @@ class ExpediaControllerTest extends TestCase
         $middleware = new ApiTokenMiddleware();
         $response = $middleware->handle($request, fn($req) => $controller->searchHotels($req));
 
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('Authorization', 'Bearer demo-key');
+        });
+
         $this->assertEquals(200, $response->status());
         $this->assertNotEmpty($response->getData(true)['hotels']);
+    }
+
+    public function test_search_hotels_with_invalid_city_returns_error()
+    {
+        Http::fake([
+            'https://test.expediapartnercentral.com/rapid/hotels*' => Http::response([
+                'message' => 'Invalid cityId',
+            ], 422)
+        ]);
+
+        $request = Request::create('/api/expedia/hotels', 'GET', ['cityId' => 'invalid']);
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->searchHotels($req));
+
+        Http::assertSent(function ($request) {
+            return $request->hasHeader('Authorization', 'Bearer demo-key');
+        });
+
+        $this->assertEquals(422, $response->status());
+        $this->assertEquals('Invalid cityId', $response->getData(true)['message']);
     }
 }


### PR DESCRIPTION
## Summary
- add success test for ExpediaController ensuring Authorization header is sent
- add error test verifying 422 response for invalid city parameters

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689398d88f588330901e01d0d087fa36