### PR TITLE
Add property content endpoint

### DIFF
--- a/app/Http/Controllers/ExpediaController.php
+++ b/app/Http/Controllers/ExpediaController.php
@@ -29,7 +29,7 @@ class ExpediaController extends Controller
      * Retrieve hotels from Expedia Rapid API.
      */
     public function searchHotels(Request $request)
-
+    {
         $validator = Validator::make($request->all(), [
             'cityId' => 'required|integer',
             'checkin' => 'required|date_format:Y-m-d',
@@ -62,6 +62,31 @@ class ExpediaController extends Controller
             'Accept' => 'application/json',
             'Authorization' => 'Bearer ' . config('services.expedia.key'),
         ])->get("https://test.expediapartnercentral.com/rapid/regions/{$region_id}", $params);
+
+        return response()->json($response->json(), $response->status());
+    }
+
+    /**
+     * Retrieve property content from Expedia Rapid API.
+     */
+    public function getPropertyContent(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'property_id' => 'required|integer',
+            'language' => 'nullable|string',
+            'include' => 'nullable|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $params = $validator->validated();
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/json',
+            'Authorization' => 'Bearer ' . config('services.expedia.key'),
+        ])->get('https://test.expediapartnercentral.com/rapid/properties/content', $params);
 
         return response()->json($response->json(), $response->status());
     }

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,4 +7,5 @@ use App\Http\Middleware\ApiTokenMiddleware;
 Route::middleware([ApiTokenMiddleware::class])->group(function () {
     Route::get('/expedia/hotels', [ExpediaController::class, 'searchHotels']);
     Route::get('/expedia/region/{region_id}', [ExpediaController::class, 'getRegion']);
+    Route::get('/expedia/property-content', [ExpediaController::class, 'getPropertyContent']);
 });

--- a/tests/Feature/ExpediaControllerTest.php
+++ b/tests/Feature/ExpediaControllerTest.php
@@ -77,4 +77,49 @@ class ExpediaControllerTest extends TestCase
         $this->assertEquals(200, $response->status());
         $this->assertEquals('Demo Region', $response->getData(true)['name']);
     }
+
+    public function test_get_property_content_returns_response()
+    {
+        Http::fake([
+            'https://test.expediapartnercentral.com/rapid/properties/content*' => Http::response([
+                'property_id' => '123',
+                'name' => 'Demo Property'
+            ], 200)
+        ]);
+
+        $request = Request::create('/api/expedia/property-content', 'GET', [
+            'property_id' => '123',
+            'language' => 'en-US',
+            'include' => 'details'
+        ]);
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->getPropertyContent($req));
+
+        $this->assertEquals(200, $response->status());
+        $this->assertEquals('Demo Property', $response->getData(true)['name']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://test.expediapartnercentral.com/rapid/properties/content'
+                && $request['property_id'] === '123'
+                && $request['language'] === 'en-US'
+                && $request['include'] === 'details';
+        });
+    }
+
+    public function test_get_property_content_requires_property_id()
+    {
+        Http::fake();
+
+        $request = Request::create('/api/expedia/property-content', 'GET');
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->getPropertyContent($req));
+
+        $this->assertEquals(422, $response->status());
+    }
 }


### PR DESCRIPTION
## Summary
- add property content retrieval to ExpediaController
- expose new `/expedia/property-content` API route
- cover property content logic with tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68939c2016f483308812790e10019c40