### PR TITLE
Add property content download endpoint

### DIFF
--- a/app/Http/Controllers/ExpediaController.php
+++ b/app/Http/Controllers/ExpediaController.php
@@ -92,6 +92,34 @@ class ExpediaController extends Controller
     }
 
     /**
+     * Download property content file from Expedia.
+     */
+    public function downloadPropertyContent(Request $request)
+    {
+        $validator = Validator::make($request->all(), [
+            'language' => 'required|string',
+            'supply_source' => 'required|string',
+        ]);
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $params = $validator->validated();
+        $signed = $this->signRequest();
+
+        $params['key'] = config('services.expedia.key');
+        $params['signature'] = $signed['signature'];
+        $params['timestamp'] = $signed['timestamp'];
+
+        $response = Http::withHeaders([
+            'Accept' => 'application/json',
+        ])->get('https://test.expediapartnercentral.com/files/properties/content', $params);
+
+        return response()->json($response->json(), $response->status());
+    }
+
+    /**
      * Retrieve property availability from Expedia Rapid API.
      */
     public function getAvailability(Request $request)

--- a/routes/api.php
+++ b/routes/api.php
@@ -8,5 +8,6 @@ Route::middleware([ApiTokenMiddleware::class])->group(function () {
     Route::get('/expedia/hotels', [ExpediaController::class, 'searchHotels']);
     Route::get('/expedia/region/{region_id}', [ExpediaController::class, 'getRegion']);
     Route::get('/expedia/property-content', [ExpediaController::class, 'getPropertyContent']);
+    Route::get('/expedia/files/property-content', [ExpediaController::class, 'downloadPropertyContent']);
     Route::get('/expedia/properties/availability', [ExpediaController::class, 'getAvailability']);
 });

--- a/tests/Feature/ExpediaControllerTest.php
+++ b/tests/Feature/ExpediaControllerTest.php
@@ -123,6 +123,51 @@ class ExpediaControllerTest extends TestCase
         $this->assertEquals(422, $response->status());
     }
 
+    public function test_download_property_content_returns_response()
+    {
+        Http::fake([
+            'https://test.expediapartnercentral.com/files/properties/content*' => Http::response([
+                'content_url' => 'https://example.com/file.zip'
+            ], 200)
+        ]);
+
+        $request = Request::create('/api/expedia/files/property-content', 'GET', [
+            'language' => 'en-US',
+            'supply_source' => 'expedia'
+        ]);
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->downloadPropertyContent($req));
+
+        $this->assertEquals(200, $response->status());
+        $this->assertEquals('https://example.com/file.zip', $response->getData(true)['content_url']);
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://test.expediapartnercentral.com/files/properties/content'
+                && $request['language'] === 'en-US'
+                && $request['supply_source'] === 'expedia'
+                && isset($request['signature'])
+                && isset($request['timestamp'])
+                && isset($request['key']);
+        });
+    }
+
+    public function test_download_property_content_requires_parameters()
+    {
+        Http::fake();
+
+        $request = Request::create('/api/expedia/files/property-content', 'GET');
+        $request->headers->set('X-API-TOKEN', 'secret-token');
+
+        $controller = new ExpediaController();
+        $middleware = new ApiTokenMiddleware();
+        $response = $middleware->handle($request, fn($req) => $controller->downloadPropertyContent($req));
+
+        $this->assertEquals(422, $response->status());
+    }
+
     public function test_get_availability_returns_response()
     {
         Http::fake([


### PR DESCRIPTION
## Summary
- support downloading property content files with `downloadPropertyContent`
- expose `/api/expedia/files/property-content` for file download
- cover property content download with feature tests

## Testing
- `composer install` *(fails: curl error 56 while downloading packages.json: CONNECT tunnel failed, response 403)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*


------
https://chatgpt.com/codex/tasks/task_e_6893a1c6360c83309250d0e107ebb91f